### PR TITLE
Clamp int64 input to tvm::Integer to [INT32_MIN, INT32_MAX]

### DIFF
--- a/include/tvm/expr.h
+++ b/include/tvm/expr.h
@@ -102,6 +102,10 @@ class Integer : public Expr {
    */
   Integer(int value) : Expr(value) {}  // NOLINT(*)
   /*!
+  /* \brief Construct integer from int64 value, clamp to INT32_MAX/MIN.
+  */
+  Integer(int64_t value) : Integer(int(value > INT32_MAX ? INT32_MAX : (value < INT32_MIN ? INT32_MIN : value))) {}  // NOLINT(*)
+  /*!
    * \brief Assign an expression to integer.
    * \param other another expression.
    */


### PR DESCRIPTION
This fixes an issue when INT64_MAX is used as slice end, and becomes -1 in tvm::Integer
